### PR TITLE
Add restore state to WIAB binary sensor

### DIFF
--- a/custom_components/magic_areas/binary_sensor/ble_tracker.py
+++ b/custom_components/magic_areas/binary_sensor/ble_tracker.py
@@ -8,7 +8,7 @@ from homeassistant.components.binary_sensor import (
     BinarySensorDeviceClass,
     BinarySensorEntity,
 )
-from homeassistant.const import ATTR_ENTITY_ID, STATE_ON
+from homeassistant.const import ATTR_ENTITY_ID
 from homeassistant.core import Event, EventStateChangedData, callback
 from homeassistant.helpers.event import async_track_state_change_event
 
@@ -47,28 +47,10 @@ class AreaBLETrackerBinarySensor(MagicEntity, BinarySensorEntity):
         }
         self._attr_is_on: bool = False
 
-    async def _restore_state(self) -> None:
-        """Restore the state of the BLE Tracker monitor sensor entity on initialize."""
-        last_state = await self.async_get_last_state()
-
-        if last_state is None:
-            _LOGGER.debug("%s: New BLE Tracker monitor sensor created", self.area.name)
-            self._attr_is_on = False
-        else:
-            _LOGGER.debug(
-                "%s: BLE Tracker monitor sensor restored [state=%s]",
-                self.area.name,
-                last_state.state,
-            )
-            self._attr_is_on = last_state.state == STATE_ON
-            self._attr_extra_state_attributes = dict(last_state.attributes)
-
-        self.schedule_update_ha_state()
-
     async def async_added_to_hass(self) -> None:
         """Call to add the system to hass."""
         await super().async_added_to_hass()
-        await self._restore_state()
+        await self.restore_state()
 
         # Setup the listeners
         await self._setup_listeners()

--- a/custom_components/magic_areas/binary_sensor/wasp_in_a_box.py
+++ b/custom_components/magic_areas/binary_sensor/wasp_in_a_box.py
@@ -69,6 +69,7 @@ class AreaWaspInABoxBinarySensor(MagicEntity, BinarySensorEntity):
     async def async_added_to_hass(self) -> None:
         """Call to add the entity to hass."""
         await super().async_added_to_hass()
+        await self.restore_state()
 
         # Check entities exist
         wasp_device_classes = self.area.feature_config(


### PR DESCRIPTION
As reported on https://github.com/jseidl/hass-magic_areas/issues/556 WIAB sensor lacked the restore state functionality of every other entity. 

Oops, my bad!