### PR TITLE
Release area state dispatcher subscriptions when entities are removed

### DIFF
--- a/custom_components/magic_areas/binary_sensor/presence.py
+++ b/custom_components/magic_areas/binary_sensor/presence.py
@@ -668,8 +668,10 @@ class AreaStateBinarySensor(AreaStateTrackerEntity, BinarySensorEntity):
 
     async def _setup_listeners(self) -> None:
         # Setup state change listener
-        async_dispatcher_connect(
-            self.hass, MagicAreasEvents.AREA_STATE_CHANGED, self._area_state_changed
+        self.async_on_remove(
+            async_dispatcher_connect(
+                self.hass, MagicAreasEvents.AREA_STATE_CHANGED, self._area_state_changed
+            )
         )
 
         self._setup_tracking_listeners()

--- a/custom_components/magic_areas/light.py
+++ b/custom_components/magic_areas/light.py
@@ -253,8 +253,10 @@ class AreaLightGroup(MagicLightGroup):
 
     async def _setup_listeners(self, _=None) -> None:
         """Set up listeners for area state chagne."""
-        async_dispatcher_connect(
-            self.hass, EVENT_MAGICAREAS_AREA_STATE_CHANGED, self.area_state_changed
+        self.async_on_remove(
+            async_dispatcher_connect(
+                self.hass, EVENT_MAGICAREAS_AREA_STATE_CHANGED, self.area_state_changed
+            )
         )
         self.async_on_remove(
             async_track_state_change_event(

--- a/tests/test_light.py
+++ b/tests/test_light.py
@@ -13,6 +13,7 @@ from homeassistant.components.light.const import DOMAIN as LIGHT_DOMAIN
 from homeassistant.components.switch.const import DOMAIN as SWITCH_DOMAIN
 from homeassistant.const import ATTR_ENTITY_ID, SERVICE_TURN_ON, STATE_OFF, STATE_ON
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.dispatcher import DATA_DISPATCHER
 
 from custom_components.magic_areas.const import (
     CONF_ENABLED_FEATURES,
@@ -21,6 +22,7 @@ from custom_components.magic_areas.const import (
     CONF_OVERHEAD_LIGHTS_ACT_ON,
     CONF_OVERHEAD_LIGHTS_STATES,
     DOMAIN,
+    EVENT_MAGICAREAS_AREA_STATE_CHANGED,
     LIGHT_GROUP_ACT_ON_OCCUPANCY_CHANGE,
     AreaStates,
 )
@@ -174,3 +176,32 @@ async def test_light_group_basic(
     # Check light group is off
     light_group_state = hass.states.get(light_group_entity_id)
     assert_state(light_group_state, STATE_OFF)
+
+
+async def test_light_group_releases_listeners_on_reload(
+    hass: HomeAssistant,
+    entities_light_one: list[MockLight],
+    entities_binary_sensor_motion_one: list[MockBinarySensor],
+    light_groups_config_entry: MockConfigEntry,
+    _setup_integration_light_groups,
+) -> None:
+    """Test that light groups unsubscribe from the area state dispatcher on reload.
+
+    A leaked subscription keeps the previous AreaLightGroup instance alive and
+    reacting to area state changes. That instance holds the MagicArea object
+    from before the reload, whose states are frozen, so it acts on state the
+    area no longer has.
+    """
+
+    def subscriber_count() -> int:
+        dispatchers = hass.data.get(DATA_DISPATCHER, {})
+        return len(dispatchers.get(EVENT_MAGICAREAS_AREA_STATE_CHANGED, {}))
+
+    subscribers_before = subscriber_count()
+    assert subscribers_before > 0
+
+    for _ in range(3):
+        await hass.config_entries.async_reload(light_groups_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+        assert subscriber_count() == subscribers_before


### PR DESCRIPTION
Hi, here's a fix for a problem I found where areas could behave strangely after changing settings, turning on lights when they shouldn't, etc.

LLM summary below:

## What's happening

`AreaLightGroup._setup_listeners` (`light.py`) and `AreaStateBinarySensor._setup_listeners` (`binary_sensor/presence.py`) call `async_dispatcher_connect()` and throw away the returned unsubscribe callback. They are the only two dispatcher subscriptions in the integration that aren't wrapped in `async_on_remove()` — `fan_control.py`, `climate_control.py` and `media_player_control.py` all register theirs correctly.

Since the subscription is never released, every config entry reload leaves the previous entities subscribed to `AREA_STATE_CHANGED`. Those instances keep a reference to the `MagicArea` object from before the reload, whose `.states` list is frozen at the moment of the reload, plus the light group configuration that was loaded at the time. `has_state()` is a plain `state in self.states` lookup, so a stale `AreaLightGroup` never observes the area's current secondary states — including `BRIGHT` — and still calls `_turn_on()` on the same `entity_id`, which resolves to the live light group.

This isn't limited to people who edit their configuration. `__init__.py` reloads every entry once on `EVENT_HOMEASSISTANT_STARTED`, so every area leaks one generation of handlers on every single startup.

## How it shows up

Whether it's visible depends on what the frozen snapshot happens to contain, which is why it looks so intermittent:

- Snapshot taken while the area was dark and occupied → the stale handler is permanently convinced it's night-time, and turns lights on in broad daylight while the area reports `bright`.
- Snapshot taken while the area was `bright` → the stale handler hits the `BRIGHT` early return and stays quiet.
- Snapshot taken while the area was clear → `is_occupied()` is false and it stays quiet.

The stale handler also carries the *old* `assigned_states`, so after changing light group settings an area can drive lights that no longer match what's saved. And because both the live and stale handlers run in the same dispatch, a light can be turned off and back on within a single event — same context id, a few milliseconds apart.

On my instance two areas had been reconfigured in the evening. From then on, every morning, they turned their sleep/accent lights on while reporting `['occupied', 'bright']`, and I could see the two handlers disagreeing:

```
10:04:00 light.main_bathroom_sink_lights on->off  ctx=019ffc14a4124ae3   <- live group: area is bright
10:04:00 light.main_bathroom_sink_lights off->on  ctx=019ffc14a4124ae3   <- stale group: "it's night and accented"
```

## Verification on a live instance

I ran this on a real install with 30 areas, counting how many light group handlers respond to a single dispatch (via the `Area state change event not for us` debug line, clustered per dispatch):

Before, on a freshly restarted instance with no config changes at all — every area at exactly 2× its configured group count, purely from the startup reload:

| area | configured groups | handlers responding |
|---|---|---|
| main_bedroom | 4 | 8 |
| main_bathroom | 5 | 10 |
| kitchen | 4 | 8 |

After the patch, and then reloading one entry three times in a row:

| area | pre-reload | after 3 reloads |
|---|---|---|
| main_bedroom | 4 | 4 |
| main_bathroom | 5 | 5 |
| kitchen | 4 | 4 |

Counts drop to exactly the number of configured light groups and stay flat across reloads. The original symptom is gone too — the area has since been `['bright', 'occupied']` with all of its configured lights staying off, where before it turned two of them on within a second.

## The fix

Wrap both subscriptions in `async_on_remove()`, matching the other platforms.

I also added a regression test asserting the `AREA_STATE_CHANGED` subscriber count is stable across three reloads. It fails on `main` (3 → 6 subscribers after one reload) and passes with the fix.

## Notes

- Test suite is unchanged otherwise: same 9 pre-existing failures before and after on my machine (HA 2026.8.1), with the new test taking passes from 21 to 22.
- There's a third unwrapped subscription I left alone: `MagicMetaArea.finalize_init` subscribes to `AREA_LOADED` in `base/magic.py` with the same pattern. It's on the area object rather than an entity, so there's no `async_on_remove()` to hang it on and the fix would be more invasive. Happy to look at it separately if you'd like.
